### PR TITLE
Allow custom team names with AI suggestions and random color assignment

### DIFF
--- a/src/commands/edit_teams.ts
+++ b/src/commands/edit_teams.ts
@@ -46,20 +46,28 @@ export const editTeamsCommand = async (ctx: BotContext): Promise<void> => {
     const teamBPlayers = [...teamComposition.teamB].sort((a, b) => a.firstName.localeCompare(b.firstName));
 
     // Форматируем сообщение для редактирования
-    const formatTeamForEdit = (players: any[], teamName: string, teamLetter: 'A' | 'B'): string => {
-      return players.map((p, i) => {
-        const escapedName = escapeHtml(p.firstName);
-        const usernameStr = p.username ? ` (@${p.username})` : '';
-        return `${i + 1}. ${escapedName}${usernameStr}`;
-      }).join('\n');
+    const formatTeamForEdit = (players: any[]): string => {
+      return players
+        .map((p, i) => {
+          const escapedName = escapeHtml(p.firstName);
+          const usernameStr = p.username ? ` (@${p.username})` : '';
+          return `${i + 1}. ${escapedName}${usernameStr}`;
+        })
+        .join('\n');
     };
 
-    const teamAStr = formatTeamForEdit(teamAPlayers, '🔴', 'A');
-    const teamBStr = formatTeamForEdit(teamBPlayers, '🔵', 'B');
+    const teamAStr = formatTeamForEdit(teamAPlayers);
+    const teamBStr = formatTeamForEdit(teamBPlayers);
 
-    const message = `✏️ <b>Ручная правка команд</b>\n\n` +
-      `<b>🔴 Команда A:</b>\n${teamAStr}\n\n` +
-      `<b>🔵 Команда B:</b>\n${teamBStr}\n\n` +
+    const teamANameRaw = gameSession.teamA || '🔴';
+    const teamBNameRaw = gameSession.teamB || '🔵';
+    const teamAName = escapeHtml(teamANameRaw);
+    const teamBName = escapeHtml(teamBNameRaw);
+
+    const message =
+      `✏️ <b>Ручная правка команд</b>\n\n` +
+      `<b>${teamAName} Команда A:</b>\n${teamAStr}\n\n` +
+      `<b>${teamBName} Команда B:</b>\n${teamBStr}\n\n` +
       `Выберите игрока для перемещения:`;
 
     // Создаем кнопки для каждого игрока
@@ -68,7 +76,7 @@ export const editTeamsCommand = async (ctx: BotContext): Promise<void> => {
     // Игроки команды A
     teamAPlayers.forEach((player, i) => {
       keyboard.push([{
-        text: `🔴→🔵 ${player.firstName}`,
+        text: `${teamANameRaw}→${teamBNameRaw} ${player.firstName}`,
         callback_data: `move_player_A_${player.id}`
       }]);
     });
@@ -76,7 +84,7 @@ export const editTeamsCommand = async (ctx: BotContext): Promise<void> => {
     // Игроки команды B
     teamBPlayers.forEach((player, i) => {
       keyboard.push([{
-        text: `🔵→🔴 ${player.firstName}`,
+        text: `${teamBNameRaw}→${teamANameRaw} ${player.firstName}`,
         callback_data: `move_player_B_${player.id}`
       }]);
     });
@@ -184,7 +192,8 @@ export const recalculateBalanceCommand = async (ctx: BotContext): Promise<void> 
       winProbability: teamService.calculateWinProbability(teamAWeight, teamBWeight),
     };
 
-    const message = teamService.formatTeamsMessage(balance);
+    const teamNames = { teamA: gameSession.teamA || '🔴', teamB: gameSession.teamB || '🔵' };
+    const message = teamService.formatTeamsMessage(balance, teamNames);
 
     await ctx.editMessageText(message + '\n\n✅ <i>Составы обновлены с учетом ваших изменений</i>', {
       parse_mode: 'HTML',

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -24,7 +24,9 @@ const generateInfoMessage = async (ctx: BotContext, playerId: number) => {
   // Проверяем статус текущего игрока
   let playerStatus = '❌ Вы не записаны на игру';
   let playerPosition = '';
-  let playerTeam = '';
+
+  const teamAName = escapeHtml(gameSession?.teamA || '🔴');
+  const teamBName = escapeHtml(gameSession?.teamB || '🔵');
 
   const playerInMain = main.find(p => p.id === playerId);
   const playerInWaiting = waiting.find(p => p.id === playerId);
@@ -36,11 +38,9 @@ const generateInfoMessage = async (ctx: BotContext, playerId: number) => {
       const playerTeamResult = await teamPlayerService.getPlayerTeam(gameSession.id, playerId);
 
       if (playerTeamResult === 'A') {
-        playerStatus = '🔴 Вы в команде A';
-        playerTeam = 'A';
+        playerStatus = `🏅 Вы в команде ${teamAName}`;
       } else if (playerTeamResult === 'B') {
-        playerStatus = '🔵 Вы в команде B';
-        playerTeam = 'B';
+        playerStatus = `🏅 Вы в команде ${teamBName}`;
       } else {
         playerStatus = '✅ Вы в основном составе';
       }
@@ -112,9 +112,10 @@ const generateInfoMessage = async (ctx: BotContext, playerId: number) => {
       const difference = Math.abs(teamAWeight - teamBWeight);
       const winProbability = teamService.calculateWinProbability(teamAWeight, teamBWeight);
 
-      mainPlayersText = `<b>🔴 Команда A</b> (${teamAWeight.toFixed(1)}):\n${teamAStr}\n\n` +
-                       `<b>🔵 Команда B</b> (${teamBWeight.toFixed(1)}):\n${teamBStr}\n\n` +
-                       `📊 Разница: ${difference.toFixed(2)} | 🎯 Вероятность победы красных: ${winProbability.toFixed(1)}%`;
+      mainPlayersText =
+        `<b>${teamAName}</b> (${teamAWeight.toFixed(1)}):\n${teamAStr}\n\n` +
+        `<b>${teamBName}</b> (${teamBWeight.toFixed(1)}):\n${teamBStr}\n\n` +
+        `📊 Разница в силе: ${difference.toFixed(2)} μ | 🎯 Шансы на победу ${teamAName}: ${winProbability.toFixed(1)}% vs ${teamBName}: ${(100 - winProbability).toFixed(1)}%`;
     }
   } else {
     // Обычный список если команды не утверждены

--- a/src/commands/teams.ts
+++ b/src/commands/teams.ts
@@ -1,6 +1,6 @@
 import { container } from 'tsyringe';
 import { BotContext } from '../bot';
-import { MESSAGES, KEYBOARDS } from '../config';
+import { KEYBOARDS } from '../config';
 import { TeamService } from '../services/team.service';
 import { TeamPlayerService } from '../services/team-player.service';
 import { checkAdminPrivateOnly } from '../utils/chat';
@@ -13,6 +13,9 @@ export const teamsCommand = async (ctx: BotContext): Promise<void> => {
       return;
     }
 
+    const text = 'text' in ctx.message! ? ctx.message.text : '';
+    const query = text.replace('/teams', '').trim();
+
     const { main } = await ctx.gameService.getWeekPlayers();
 
     if (main.length < 16) {
@@ -22,21 +25,46 @@ export const teamsCommand = async (ctx: BotContext): Promise<void> => {
 
     const teamService = container.resolve(TeamService);
     const balance = teamService.generateBalancedTeams(main);
-    
+
+    let teamNames = { teamA: '🔴', teamB: '🔵' };
+
+    if (query) {
+      if (query.toLowerCase() === 'ai') {
+        await ctx.reply('🤖 Генерирую названия команд...');
+        const response = await ctx.aiService.generateResponse(
+          'Придумай два смешных и классных названия футбольных команд. Ответь в формате "Название1;Название2" без лишнего текста.'
+        );
+        const parts = response.split(/;|\n|,|\|/).map(p => p.trim()).filter(Boolean);
+        if (parts.length >= 2) {
+          teamNames = { teamA: parts[0], teamB: parts[1] };
+        }
+      } else {
+        const parts = query.split(/;|,|\n/).map(p => p.trim()).filter(Boolean);
+        if (parts.length >= 2) {
+          teamNames = { teamA: parts[0], teamB: parts[1] };
+        }
+      }
+    }
+
+    // Если используются стандартные названия, случайным образом выбираем цвет
+    if (!query && Math.random() < 0.5) {
+      teamNames = { teamA: '🔵', teamB: '🔴' };
+    }
+
     // Сохраняем составы команд в базу данных
     const { week, year } = getCurrentWeek();
     
     const gameSession = await prisma.gameSession.upsert({
       where: { week_year: { week, year } },
       update: {
-        teamA: '',
-        teamB: '',
+        teamA: teamNames.teamA,
+        teamB: teamNames.teamB,
       },
       create: {
         week,
         year,
-        teamA: '',
-        teamB: '',
+        teamA: teamNames.teamA,
+        teamB: teamNames.teamB,
       },
     });
 
@@ -48,7 +76,7 @@ export const teamsCommand = async (ctx: BotContext): Promise<void> => {
       balance.teamB.players
     );
 
-    const message = teamService.formatTeamsMessage(balance);
+    const message = teamService.formatTeamsMessage(balance, teamNames);
 
     await ctx.reply(message, {
       reply_markup: {

--- a/src/services/team.service.ts
+++ b/src/services/team.service.ts
@@ -110,7 +110,10 @@ export class TeamService {
     };
   }
 
-  public formatTeamsMessage(balance: TeamBalance): string {
+  public formatTeamsMessage(
+    balance: TeamBalance,
+    teamNames: { teamA: string; teamB: string } = { teamA: '🔴', teamB: '🔵' }
+  ): string {
     const formatTeam = (team: Team, name: string): string => {
       const playersList = team.players
         .map((p, i) => {
@@ -120,17 +123,29 @@ export class TeamService {
         })
         .join('\n');
 
-      return `<b>${name} команда</b> (${team.totalRating.toFixed(1)}):\n${playersList}`;
+      const escapedTeamName = escapeHtml(name);
+      return `<b>${escapedTeamName} команда</b> (${team.totalRating.toFixed(1)}):\n${playersList}`;
     };
 
-    const teamAStr = formatTeam(balance.teamA, '🔴');
-    const teamBStr = formatTeam(balance.teamB, '🔵');
+    const teamAStr = formatTeam(balance.teamA, teamNames.teamA);
+    const teamBStr = formatTeam(balance.teamB, teamNames.teamB);
 
     // Определяем, какая команда сильнее
-    const strongerTeam = balance.teamA.totalRating > balance.teamB.totalRating ? '🔴 красных' : '🔵 синих';
-    const weakerTeam = balance.teamA.totalRating > balance.teamB.totalRating ? '🔵 синих' : '🔴 красных';
-    const winProb = balance.teamA.totalRating > balance.teamB.totalRating ? balance.winProbability : 100 - balance.winProbability;
+    const strongerTeamName =
+      balance.teamA.totalRating > balance.teamB.totalRating ? teamNames.teamA : teamNames.teamB;
+    const weakerTeamName =
+      balance.teamA.totalRating > balance.teamB.totalRating ? teamNames.teamB : teamNames.teamA;
+    const winProb =
+      balance.teamA.totalRating > balance.teamB.totalRating
+        ? balance.winProbability
+        : 100 - balance.winProbability;
 
-    return `${teamAStr}\n\n${teamBStr}\n\n📊 Разница в силе: ${balance.difference.toFixed(1)} μ\n🎯 Шансы на победу ${strongerTeam}: ${winProb.toFixed(0)}% vs ${weakerTeam}: ${(100 - winProb).toFixed(0)}%`;
+    const escapedStronger = escapeHtml(strongerTeamName);
+    const escapedWeaker = escapeHtml(weakerTeamName);
+    return (
+      `${teamAStr}\n\n${teamBStr}\n\n` +
+      `📊 Разница в силе: ${balance.difference.toFixed(1)} μ\n` +
+      `🎯 Шансы на победу ${escapedStronger}: ${winProb.toFixed(0)}% vs ${escapedWeaker}: ${(100 - winProb).toFixed(0)}%`
+    );
   }
 }

--- a/src/tests/team.service.spec.ts
+++ b/src/tests/team.service.spec.ts
@@ -87,20 +87,28 @@ describe('TeamService', () => {
   it('should format team message correctly', () => {
     const result = teamService.generateBalancedTeams(mockPlayers);
     const message = teamService.formatTeamsMessage(result);
-    
+
     expect(message).toContain('🔴');
     expect(message).toContain('🔵');
-    expect(message).toContain('Разница:');
-    expect(message).toContain('Вероятность победы красных:');
+    expect(message).toContain('Разница в силе:');
+    expect(message).toContain('Шансы на победу');
     expect(message).toContain('%');
-    
+
     result.teamA.players.forEach(player => {
       expect(message).toContain(player.firstName);
     });
-    
+
     result.teamB.players.forEach(player => {
       expect(message).toContain(player.firstName);
     });
+  });
+
+  it('should format message with custom team names', () => {
+    const result = teamService.generateBalancedTeams(mockPlayers);
+    const message = teamService.formatTeamsMessage(result, { teamA: 'Львы', teamB: 'Тигры' });
+
+    expect(message).toContain('Львы');
+    expect(message).toContain('Тигры');
   });
 
   it('should handle players with equal skills', () => {


### PR DESCRIPTION
## Summary
- Support custom team names when generating rosters
- Offer AI-powered name suggestions and store chosen names
- Show selected team names in edit and info commands
- Randomly assign red/blue markers to teams when using default names and persist the choice
- Update edit menu buttons to reflect chosen team names

## Testing
- `npm test -- --run` *(fails: GameService tests)*

------
https://chatgpt.com/codex/tasks/task_e_6898482f65288320b323fa712f2999f6